### PR TITLE
update datas de selecao 2023

### DIFF
--- a/datas_selecao.json
+++ b/datas_selecao.json
@@ -2,18 +2,18 @@
   "states": [
     {
       "title": "inscrições abertas",
-      "date_active": "20 05 2022 0 0",
-      "date_content": "20 06 2022 23 59"
+      "date_active": "19 05 2023 0 0",
+      "date_content": "19 06 2023 23 59"
     },
     {
       "title": "primeira fase",
-      "date_active": "21 06 2022 0 0",
-      "date_content": "25 06 2022 09 0"
+      "date_active": "20 06 2023 0 0",
+      "date_content": "24 06 2023 09 0"
     },
     {
       "title": "segunda fase",
-      "date_active": "25 06 2022 12 0",
-      "date_content": "01 08 2022 09 0"
+      "date_active": "24 06 2023 12 0",
+      "date_content": "10 07 2023 09 0"
     },
     {
       "title": "resultados",


### PR DESCRIPTION
Inclui datas da selecao 2023. Falta confirmar horario das primeiras e segundas fases e data dos resultados.